### PR TITLE
Replace obsolete devdocs links

### DIFF
--- a/src/pages/style-guide/content/buttons-and-links.md
+++ b/src/pages/style-guide/content/buttons-and-links.md
@@ -29,7 +29,7 @@ Buttons can be used for:
 
 Button types are primary, secondary, and tertiary. Each page should have a maximum limit of one primary button. Split buttons include multiple actions. Button counts in a Button Bar or any array of buttons should be limited to four buttons, maximum.
 
-**For design specs,** see [Buttons](https://devdocs.magento.com/guides/v2.4/pattern-library/controls/buttons/buttons.html) and [Button Bar](https://devdocs.magento.com/guides/v2.4/pattern-library/controls/button-bar/button-bar.html) patterns.
+**For design specs,** see [Buttons](https://developer.adobe.com/commerce/admin-developer/pattern-library/controls/buttons/) and [Button Bar](https://developer.adobe.com/commerce/admin-developer/pattern-library/controls/button-bar/) patterns.
 
 ## Links
 

--- a/src/pages/style-guide/content/voice-and-tone.md
+++ b/src/pages/style-guide/content/voice-and-tone.md
@@ -30,7 +30,7 @@ Content should be gender neutral. To avoid “his” or “her” pronouns, chan
 
 **Follow accessibility and readability standards.**
 
-To ensure that users with special needs – including the use of screen readers – can easily access your content, follow the content and design standards in the Admin Design Pattern Library's [Accessibility Guidelines](https://devdocs.magento.com/guides/v2.4/pattern-library/general/accessibilityguideline/accessibilityGuideline.html).
+To ensure that users with special needs – including the use of screen readers – can easily access your content, follow the content and design standards in the Admin Design Pattern Library's [Accessibility Guidelines](https://developer.adobe.com/commerce/admin-developer/pattern-library/general/accessibility-guidelines/).
 
 For more guidance, see this summary of [Web Content Accessibility Guidelines (WCAG) 2.0 standards](https://www.w3.org/WAI/WCAG20/glance/).
 
@@ -44,7 +44,7 @@ When uncertain about using a correct term or style, consult the following docume
 
 *  The [Glossary](https://glossary.magento.com/)
 
-*  [Admin Design Pattern Library](https://devdocs.magento.com/guides/v2.4/pattern-library/bk-pattern.html)
+*  [Admin Design Pattern Library](https://developer.adobe.com/commerce/admin-developer/pattern-library/)
 
 For standards not included in those documents, we use the following stylebooks:
 
@@ -129,7 +129,7 @@ Most websites have eliminated personal pronouns because using pronouns like “y
 
 The tone in UI content – including navigation, tables, forms, and calls to action – is usually more focused on accuracy and conciseness, but the same standards apply: Use clear, plain language and consult global conventions to ensure content is understood by all.
 
-Consistency is critical. For example, wherever content is displayed in [Data Tables](https://devdocs.magento.com/guides/v2.4/pattern-library/displaying-data/datatable/datatable.html) or [Form Elements](https://devdocs.magento.com/guides/v2.4/pattern-library/getting-user-input/form_elements/form_elements.html), it should use standard or global conventions.
+Consistency is critical. For example, wherever content is displayed in [Data Tables](https://developer.adobe.com/commerce/admin-developer/pattern-library/displaying-data/datatable/) or [Form Elements](https://devdocs.magento.com/guidehttps://developer.adobe.com/commerce/admin-developer/pattern-library/getting-user-input/form-elements/), it should use standard or global conventions.
 
 *Correct example of button-label consistency, in a task flow:*
 

--- a/src/pages/style-guide/index.md
+++ b/src/pages/style-guide/index.md
@@ -5,7 +5,7 @@ description: Review style guide resources for designing UI elements and writing 
 
 # Admin Style Guide
 
-The Admin guide sets our foundational design, writing, and content standards for the [Admin](https://glossary.magento.com/magento-admin) software. For more specific user-interface standards, see the [Admin Design Pattern Library](https://devdocs.magento.com/guides/v2.4/pattern-library/bk-pattern.html).
+The Admin guide sets our foundational design, writing, and content standards for the [Admin](https://glossary.magento.com/magento-admin) software. For more specific user-interface standards, see the [Admin Design Pattern Library](https://developer.adobe.com/commerce/admin-developer/pattern-library/).
 
 **Why follow the style guide?** A style guide is the best tool for designers and writers to establish and maintain consistency, which improves communication throughout the application. A seamless look-and-feel and a steady, encouraging writing style make the application usable and engaging.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to `https://devdocs.magento.com` topics that have already been migrated to the Adobe Devsite (`https://developer.adobe.com`).

## Affected pages

- See changed files

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
