### PR TITLE
Update slideouts-modals-overlays.md

### DIFF
--- a/src/pages/pattern-library/containers/slideouts-modals-overlays.md
+++ b/src/pages/pattern-library/containers/slideouts-modals-overlays.md
@@ -5,7 +5,7 @@ keywords:
   - Extensions
 ---
 
-# Slide-out panesl, modal windows, and overlays
+# Slide-out panels, modal windows, and overlays
 
 You can focus user attention on a specific bit of content, isolated action, process or sub-process by using a "Slide-out Panel", "Modal Window" or "Overlay" component in the interface. Display of these components is triggered by a particular user action that interrupts their current task. The user must then take some required action to return to their primary task and continue (in most cases). The active state of any of overlays should occupy the topmost level of the z-index.
 


### PR DESCRIPTION
typo update

## Purpose of this pull request

Update a typo on the title "Slide-out panesl, modal windows, and overlays" 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/admin-developer/pattern-library/containers/slideouts-modals-overlays/



<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-admin-developer/blob/main/.github/CONTRIBUTING.md) for more information.
-->
