### PR TITLE
Add validation for custom headers

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,3 +1,4 @@
+import remarkHeadingId from "remark-heading-id";
 import remarkValidateLinks from "remark-validate-links";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkLintFrontmatterSchema from "remark-lint-frontmatter-schema";
@@ -5,6 +6,7 @@ import remarkLintNoDeadUrls from "remark-lint-no-dead-urls";
 
 const remarkConfig = {
 	plugins: [
+		remarkHeadingId,
 		remarkValidateLinks,
 		remarkFrontmatter,
 		[
@@ -26,7 +28,7 @@ const remarkConfig = {
 					"https://www.php.net"
 				]
 			}
-		],
+		]
 	],
 };
 export default remarkConfig;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "remark-cli": "^10.0.1",
     "remark-frontmatter": "4.0.1",
+    "remark-heading-id": "^1.0.1",
     "remark-lint-frontmatter-schema": "^3.15.2",
     "remark-lint-no-dead-urls": "^1.1.0",
     "remark-validate-links": "^11.0.2"

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,7 +15,7 @@ Learn how to customize the Adobe Commerce and Magento Open Source Admin applicat
 
 <Resources slots="heading, links"/>
 
-## Resources
+## Resources {#resources-id}
 
 *  [Commerce open-source projects](https://developer.adobe.com/open/magento)
 *  [Community Slack workspace](https://opensource.magento.com/slack)
@@ -23,7 +23,7 @@ Learn how to customize the Adobe Commerce and Magento Open Source Admin applicat
 
 ## Overview
 
-This documentation provides resources for customizing the Adobe Commerce and Magento Open Source Admin application.
+This documentation provides [resources](#resources) for customizing the Adobe Commerce and Magento Open Source Admin application.
 
 ## Discover
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -23,7 +23,7 @@ Learn how to customize the Adobe Commerce and Magento Open Source Admin applicat
 
 ## Overview
 
-This documentation provides [resources](#resources) for customizing the Adobe Commerce and Magento Open Source Admin application.
+This documentation provides [resources](#resources-id) for customizing the Adobe Commerce and Magento Open Source Admin application.
 
 ## Discover
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,7 +15,7 @@ Learn how to customize the Adobe Commerce and Magento Open Source Admin applicat
 
 <Resources slots="heading, links"/>
 
-## Resources {#resources-id}
+## Resources
 
 *  [Commerce open-source projects](https://developer.adobe.com/open/magento)
 *  [Community Slack workspace](https://opensource.magento.com/slack)
@@ -23,7 +23,7 @@ Learn how to customize the Adobe Commerce and Magento Open Source Admin applicat
 
 ## Overview
 
-This documentation provides [resources](#resources-id) for customizing the Adobe Commerce and Magento Open Source Admin application.
+This documentation provides resources for customizing the Adobe Commerce and Magento Open Source Admin application.
 
 ## Discover
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6996,6 +6996,7 @@ __metadata:
     react-dom: ^17.0.2
     remark-cli: ^10.0.1
     remark-frontmatter: 4.0.1
+    remark-heading-id: ^1.0.1
     remark-lint-frontmatter-schema: ^3.15.2
     remark-lint-no-dead-urls: ^1.1.0
     remark-validate-links: ^11.0.2
@@ -17780,6 +17781,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-heading-id@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "remark-heading-id@npm:1.0.1"
+  dependencies:
+    lodash: ^4.17.21
+    unist-util-visit: ^1.4.0
+  checksum: 20fd8072436280936dd76cf3a86d3e8e4f89bb4440863ea67d5c2ad27b74e858350aaf5a56a292bdb7f99c28fa823a83d8cfac87bfc410ebb39d23594d5905d8
+  languageName: node
+  linkType: hard
+
 "remark-lint-frontmatter-schema@npm:^3.15.2":
   version: 3.15.2
   resolution: "remark-lint-frontmatter-schema@npm:3.15.2"
@@ -20663,7 +20674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit@npm:^1.0.0, unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.1":
+"unist-util-visit@npm:^1.0.0, unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.0, unist-util-visit@npm:^1.4.1":
   version: 1.4.1
   resolution: "unist-util-visit@npm:1.4.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6452,9 +6452,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001335, caniuse-lite@npm:^1.0.30001366":
-  version: 1.0.30001462
-  resolution: "caniuse-lite@npm:1.0.30001462"
-  checksum: e4a57d7851eec65e7c9b6c11c4bbcecdc49d87b1b01bff3c15ea27efb05f959891b4c70ac169842067c134d6fa126d9ad5a91d0f85c7387c5bd912eaf41ea647
+  version: 1.0.30001564
+  resolution: "caniuse-lite@npm:1.0.30001564"
+  checksum: 5b53749a2e9057e74c5a129fc214fa4434d3f0c3faadbec176efa03b44e40f9c1ef8ceec979f0dd186f7a142476713129df9263e012a178351ba7807217f157a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a [remark-heading-id](https://github.com/imcuttle/remark-heading-id) plugin that allows validation of custom headers via remark-validate-links.

Internal ticket: COMDOX-857

## Test

1. Initial [green run](https://github.com/AdobeDocs/commerce-admin-developer/actions/runs/6963160732).
1. [Red run](https://github.com/AdobeDocs/commerce-admin-developer/actions/runs/6963228461/job/18948445839?pr=85#step:11:14) with custom ID `{#resources-id}` and incorrect reference `#resources`
1. [Green run](https://github.com/AdobeDocs/commerce-admin-developer/actions/runs/6963287060/job/18948598867) with custom ID `{#resources-id}` and correct reference `#resources-id`