### PR TITLE
Upgrade theme to v4.11.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-admin-developer"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.11.9",
+    "@adobe/gatsby-theme-aio": "4.11.14",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/pages/pattern-library/staging-patterns/module.md
+++ b/src/pages/pattern-library/staging-patterns/module.md
@@ -59,5 +59,3 @@ The "Load More" button appears at the bottom of the list of scheduled updates. B
 ## Assets
 
 [Download Scheduled Changes Module source](https://devdocs.magento.com/download/Scheduled-Changes-Module-Source.psd)
-
-If you have questions about the Scheduled Update Module, please [contact us](https://magento.com/company/contact-us).

--- a/src/pages/pattern-library/staging-patterns/timeline-dashboard.md
+++ b/src/pages/pattern-library/staging-patterns/timeline-dashboard.md
@@ -95,5 +95,3 @@ This is an alternative view to the timeline in data table format. The functional
 ## Assets
 
 [Download Timeline Dashboard source](https://devdocs.magento.com/download/timeline-dashboard.psd)
-
-If you have questions about the Timeline Dashboard, please [contact us](https://magento.com/company/contact-us).

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.11.9":
-  version: 4.11.9
-  resolution: "@adobe/gatsby-theme-aio@npm:4.11.9"
+"@adobe/gatsby-theme-aio@npm:4.11.14":
+  version: 4.11.14
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.14"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 57693d220f785d6ffa8c81c09fce1b15240de6ce483df835b5b5b373124e1b1349c99f170b2694c25b2271aff84b16eef8e5975c1f7b33f24a297a3b03e8e871
+  checksum: b93a25de446629f42f702cbe45e756fcc009857e5f96899a2b55e7465aed5246a85bd1cb2a57bdb3e572ed15d1ffd5df76e7bc992c5ce823df468634ecac54a6
   languageName: node
   linkType: hard
 
@@ -7189,7 +7189,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-admin-developer@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.11.9
+    "@adobe/gatsby-theme-aio": 4.11.14
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) upgrades theme to [v4.11.14](https://github.com/adobe/aio-theme/compare/%40adobe/gatsby-theme-aio%404.11.9...adobe/gatsby-theme-aio%404.11.14).

## Preview

https://developer-stage.adobe.com/commerce/admin-developer/
