### PR TITLE
Fix yarn dev

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -43,7 +43,7 @@ export const onClientEntry = () => {
 export const onRouteUpdate = ({ location, prevLocation }) => {
   if (isBrowser) {
     function watchAndFireAnalytics() {
-      if (typeof window._satellite !== 'undefined') {
+      if (typeof window._satellite !== 'undefined' && typeof window._satellite.track === 'function') {
         _satellite.track('state',
           {
             xdm: {},


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes `yarn dev` error:
```
Error in function watchAndFireAnalytics in ./gatsby-browser.js:48
_satellite.track is not a function
```

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none
